### PR TITLE
Separate getServices route and how_id fetching

### DIFF
--- a/src/controllers/participantController.js
+++ b/src/controllers/participantController.js
@@ -15,7 +15,8 @@ const ParticipantInfoFields = `
       participant_general_info (
         first_name,
         last_name,
-        status
+        status,
+        how_id
       )
     )
   ),
@@ -26,11 +27,11 @@ const ParticipantInfoFields = `
       participant_general_info (
         first_name,
         last_name,
-        status
+        status,
+        how_id
       )
     )
-  ),
-  participant_services(*)
+  )
 `;
 const howParticipantInfoFields = `
   id,
@@ -62,7 +63,8 @@ const mainParticipantInfoFields = `
     first_name,
     last_name,
     status,
-    type
+    type,
+    how_id
   )
 `;
 
@@ -162,6 +164,30 @@ const participantController = {
         .select(howParticipantInfoFields)
         .eq('id', participantid)
         .single();
+
+      if (error) {
+        console.error(error.message);
+        return res.status(400).json({ error: error.message });
+      }
+      if (data) {
+        return res.json(data);
+      }
+    } catch (error) {
+      console.error(error.message);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+  async getParticipantServices(req, res) {
+    try {
+      const { participantid } = req.params;
+      if (!participantid) {
+        return res.status(400).json({ error: 'Participant ID is required' });
+      }
+      console.log('Fetching participant services:', participantid);
+      const { data, error } = await supabase
+        .from('participant_services')
+        .select(`*`)
+        .eq('id', participantid);
 
       if (error) {
         console.error(error.message);

--- a/src/routes/participantRoutes.js
+++ b/src/routes/participantRoutes.js
@@ -7,6 +7,10 @@ router.get('/', participantController.getParticipants);
 router.get('/carepartners', participantController.getCarePartners);
 router.get('/:participantid', participantController.getParticipantInfo);
 router.get('/how/:participantid', participantController.getParticipantHOWInfo);
+router.get(
+  '/services/:participantid',
+  participantController.getParticipantServices
+);
 router.put('/:participantid', participantController.updateParticipant);
 router.delete('/:participantid', participantController.deleteParticipant);
 router.delete(


### PR DESCRIPTION
- Separate route for getting services (so that if there are a lot of them, they do not slow down getting general participant data for the GeneralInfo page and header)
-  Now, how_id is fetched from the backend when getting participants (used in Database list) and getting participant info (used in GeneralInfo page and header) 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published
